### PR TITLE
 Enhancing Module Software Configuration for Multiple Container Registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,7 +547,7 @@ In this example, setting the `task.ext.override_configured_docker_registry` in t
 
 #### 5.2.2.1 Managing `process.ext.override_configured_docker_registry` with Optional Configurations
 
-To provide flexibility in managing the `process.ext.override_configured_docker_registry` setting, users can create an optional configuration file outside of the `nextflow.config` specifying the desired boolean value. This file can then be included in the pipeline using the `-c` option in commandline.
+To provide greater flexibility in managing the `process.ext.override_configured_docker_registry` setting, users can create an optional configuration file separate from the `nextflow.config`, specifying the desired boolean value. This file can then be included into the pipeline by using the `-c` option on the commandline.
 
 For example, you can create a configuration file named `azure_configuration.config` to set the default value for `process.ext.override_configured_docker_registry`. For example:
 

--- a/README.md
+++ b/README.md
@@ -516,12 +516,12 @@ Below is an example of a `container` directive specifying the software requireme
 ```
 container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
     'https://depot.galaxyproject.org/singularity/fastqc:0.11.9--0' :
-    (params.override_default_container_registry ? 'acrgspimages.io/biocontainers/fastqc:0.11.9--0' : 'biocontainers/fastqc:0.11.9--0') }"
+    (params.override_default_container_registry ? 'docker.io/biocontainers/fastqc:v0.11.9_cv8' : 'biocontainers/fastqc:0.11.9--0') }"
 ```
 
-In this example, when the `--override_default_container_registry` parameter is set to `true`, the default Docker registry (`quay.io`) is overridden, and the pipeline uses the GSP Azure container registry (`acrgspimages.io`) instead.
+In this example, when the `--override_default_container_registry` parameter is set to `true`, the default Docker registry (`quay.io`) is overridden, and the pipeline uses the DockerHub container registry (`docker.io`) instead.
 
-When running on IRIDA Next, the Azure configuration file will automatically set the `--override_default_container_registry` parameter to `true` to ensure that the Azure container registry is used for any processes with the `container` directive conditional check.
+When running on IRIDA Next, the Azure configuration file will automatically set the `--override_default_container_registry` parameter to `true` to ensure that thlternative registry can be used for any processes with the `container` directive conditional check.
 
 #### 5.2.2.1 Additional Configurations for Supporting the `--override_default_container_registry` Parameter
 
@@ -534,7 +534,7 @@ Add the `override_default_container_registry` parameter to the `nextflow.config`
 ```
 params {
 
-    // Override container registry for Docker in Azure
+    // Override default container registry
     override_default_container_registry = false
 
 }
@@ -551,7 +551,7 @@ Add the new parameter to the definition input/output properties in the `nextflow
       "properties" : {
         "override_default_container_registry": {
             "type": "boolean",
-            "description": "Determines whether to override the default Docker registry (quay.io) with the Azure private container registry (acrgspimages.io). Defaults to false, set to true in Azure configuration file for IRIDA Next.",
+            "description": "Determines whether to override the default Docker registry (quay.io) with an alternate container registry (e.g. docker.io). Defaults to false.",
             "fa_icon": "fas fa-question-circle",
             "default": false
         }

--- a/README.md
+++ b/README.md
@@ -503,7 +503,11 @@ container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity
     'biocontainers/fastqc:0.11.9--0' }"
 ```
 
-For IRIDA Next Nextflow pipelines running in Azure and using Docker, the default container registry should be set to the publicly available `quay.io` registry in the `nextflow.config` file using the `docker.registry` parameter.
+Since IRIDA Next Nextflow pipelines aim to follow [nf-core](https://nf-co.re/docs/usage/getting_started/configuration#docker-registries) standards, the default container registry should be set to the publicly available `quay.io` registry in the `nextflow.config` file using the `docker.registry` parameter.
+
+```
+docker.registry = 'quay.io'
+```
 
 For more information, see the [Nextflow containers][] documentation and the [nf-core modules software requirements][] guide.
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ This document describes the specification for developing [IRIDA Next][irida-next
   - [5.1. nf-core modules](#51-nf-core-modules)
   - [5.2. Local modules](#52-local-modules)
     - [5.2.1. Module software requirements](#521-module-software-requirements)
+    - [5.2.2 Configuring Module Software with Private Container Registries](#522-configuring-module-software-with-private-container-registries)
+      - [5.2.2.1 Additional Configurations for Supporting the `--override_default_container_registry` Parameter](#5221-additional-configurations-for-supporting-the---override_default_container_registry-parameter)
 - [6. Resource requirements](#6-resource-requirements)
   - [6.1. Process resource label](#61-process-resource-label)
     - [6.1.1. Accepted resource labels](#611-accepted-resource-labels)

--- a/README.md
+++ b/README.md
@@ -521,7 +521,7 @@ container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity
 
 In this example, when the `--override_default_container_registry` parameter is set to `true`, the default Docker registry (`quay.io`) is overridden, and the pipeline uses the DockerHub container registry (`docker.io`) instead.
 
-When running on IRIDA Next, the Azure configuration file will automatically set the `--override_default_container_registry` parameter to `true` to ensure that thlternative registry can be used for any processes with the `container` directive conditional check.
+When running on IRIDA Next, the Azure configuration file will automatically set the `--override_default_container_registry` parameter to `true` to ensure that the alternative registry can be used for any processes with the `container` directive conditional check.
 
 #### 5.2.2.1 Additional Configurations for Supporting the `--override_default_container_registry` Parameter
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ This document describes the specification for developing [IRIDA Next][irida-next
   - [5.2. Local modules](#52-local-modules)
     - [5.2.1. Module software requirements](#521-module-software-requirements)
     - [5.2.2 Configuring Module Software with Private or Alternate Container Registries](#522-configuring-module-software-with-private-or-alternate-container-registries)
-      - [5.2.2.1 Managing `process.ext.override_configured_container_registry` with Optional Configurations](#5221-managing-processextoverride_configured_container_registry-with-optional-configurations)
+      - [5.2.2.1 Example: Overriding Container Registries with the `container` Directive](#5221-example-overriding-container-registries-with-the-container-directive)
+      - [5.2.2.2 Managing Optional Container Registry Overrides](#5222-managing-optional-container-registry-overrides)
 - [6. Resource requirements](#6-resource-requirements)
   - [6.1. Process resource label](#61-process-resource-label)
     - [6.1.1. Accepted resource labels](#611-accepted-resource-labels)
@@ -534,6 +535,8 @@ process.ext.override_configured_container_registry = true
 
 This custom extension allows us to define configurations beyond the standard Nextflow syntax, tailored to the needs of specific processes in the workflow. When a process runs, the value of `process.ext.override_configured_container_registry` is accessed within the `container` directive as `task.ext.override_configured_container_registry`. The `task` context refers to the specific instance of a process execution, encompassing all relevant attributes and extensions for that instance. This setup ensures that any custom settings, such as overriding the default container registries, are correctly applied during the execution of the pipeline.
 
+#### 5.2.2.1 Example: Overriding Container Registries with the `container` Directive
+
 To specify an alternative registry for a process, include a conditional check with `task.ext.override_configured_container_registry` in the nested ternary operator of the `container` directive. For example:
 
 ```
@@ -548,7 +551,7 @@ In this example, setting the `task.ext.override_configured_container_registry` i
 
 By using `!= false` in the condition, we ensure that the process will follow the alternative registry path whenever `task.ext.override_configured_container_registry` is set to any value other than `false` (including `true` or `null`). This approach provides flexibility by allowing different registry configurations to be applied without needing explicit overrides for every scenario.
 
-#### 5.2.2.1 Managing `process.ext.override_configured_container_registry` with Optional Configurations
+#### 5.2.2.2 Managing Optional Container Registry Overrides
 
 To provide greater flexibility in managing the `process.ext.override_configured_container_registry` setting, users can create an optional configuration file separate from the `nextflow.config` to define whether an alternative container registry can be used in the pipeline. This file can then be included into the Nextflow pipeline by using the `-c` option on the commandline.
 
@@ -800,3 +803,4 @@ specific language governing permissions and limitations under the License.
 [security-alerts.png]: images/security-alerts.png
 [nf-iridanext]: https://github.com/phac-nml/nf-iridanext
 [nf-test]: https://www.nf-test.com/
+[def]: #52

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This document describes the specification for developing [IRIDA Next][irida-next
   - [5.2. Local modules](#52-local-modules)
     - [5.2.1. Module software requirements](#521-module-software-requirements)
     - [5.2.2 Configuring Module Software with Private Container Registries](#522-configuring-module-software-with-private-container-registries)
-      - [5.2.2.1 Additional Configurations for Supporting the `--override_default_container_registry` Parameter](#5221-additional-configurations-for-supporting-the---override_default_container_registry-parameter)
+      - [5.2.2.1 Additional Configurations for Supporting the `--override_configured_docker_registry` Parameter](#5221-additional-configurations-for-supporting-the---override_configured_docker_registry-parameter)
 - [6. Resource requirements](#6-resource-requirements)
   - [6.1. Process resource label](#61-process-resource-label)
     - [6.1.1. Accepted resource labels](#611-accepted-resource-labels)
@@ -523,27 +523,27 @@ This setting automatically prefixes each container name with the specified regis
 
 When the default registry is set to `quay.io`, containers are downloaded from `quay.io` by default (e.g., `biocontainers/fastqc:0.11.9--0` becomes `quay.io/biocontainers/fastqc:0.11.9--0`). This configuration can be problematic if the pipeline includes containers from multiple registries, such as `quay.io` and `docker.io`, since only one default registry can be configured at a time.
 
-Our chosen solution is to designate `quay.io` as the default container registry. To accommodate containers from alternative registries (e.g., `docker.io`), we introduce the `override_default_container_registry` parameter. This parameter directs the pipeline to remove the default prefix from the container name, ensuring proper download from the specified private or alternative container registry.
+Our chosen solution is to maintain nf-core standards and designate `quay.io` as the default `docker.registry`. To accommodate containers from alternative registries (e.g., `docker.io`), we introduce the `override_configured_docker_registry` parameter. This parameter directs the pipeline to remove the default prefix from the container name, ensuring proper download from the specified private or alternative container registry.
 
-To specify an alternative registry for a module, use the `container` directive with a conditional check using the `params.override_default_container_registry` within a nested ternary operator in its closure.
+To specify an alternative registry for a module, use the `container` directive with a conditional check using the `params.override_configured_docker_registry` within a nested ternary operator in its closure.
 
 Below is an example of a `container` directive specifying the software requirements for a module in an IRIDA Next Nextflow pipeline:
 
 ```
 container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
     'https://depot.galaxyproject.org/singularity/fastqc:0.11.9--0' :
-    (params.override_default_container_registry ? 'docker.io/biocontainers/fastqc:v0.11.9_cv8' : 'biocontainers/fastqc:0.11.9--0') }"
+    (params.override_configured_docker_registry ? 'docker.io/biocontainers/fastqc:v0.11.9_cv8' : 'biocontainers/fastqc:0.11.9--0') }"
 ```
 
-In this example, the `override_default_container_registry` parameter ensures the default Docker registry (`quay.io`) is overridden, allowing the pipeline to use the DockerHub container registry (`docker.io`) instead.
+In this example, the `override_configured_docker_registry` parameter ensures the default Docker registry (`quay.io`) is overridden, allowing the pipeline to use the DockerHub container registry (`docker.io`) instead.
 
-#### 5.2.2.1 Additional Configurations for Supporting the `--override_default_container_registry` Parameter
+#### 5.2.2.1 Additional Configurations for Supporting the `--override_configured_docker_registry` Parameter
 
-To enable dynamic selection of container registries within the IRIDA Next Nextflow pipeline modules when using the `--override_default_container_registry parameter`, additional Nextflow configuration files need to be updated or implemented.
+To enable dynamic selection of container registries within the IRIDA Next Nextflow pipeline modules when using the `--override_configured_docker_registry parameter`, additional Nextflow configuration files need to be updated or implemented.
 
 1. Update the `nextflow.config` File and Define the Parameter in the Schema
 
-   - Update the `nextflow.config file` to include the `override_default_container_registry parameter`, and add this new parameter to the `nextflow_schema.json` file:
+   - Update the `nextflow.config file` to include the `override_configured_docker_registry parameter`, and add this new parameter to the `nextflow_schema.json` file:
 
 **nextflow.config**:
 
@@ -551,7 +551,7 @@ To enable dynamic selection of container registries within the IRIDA Next Nextfl
 params {
 
     // Override default container registry
-    override_default_container_registry = true
+    override_configured_docker_registry = true
 
 }
 ```
@@ -563,7 +563,7 @@ params {
   "definitions": {
     input_output_options": {
       "properties" : {
-        "override_default_container_registry": {
+        "override_configured_docker_registry": {
             "type": "boolean",
             "description": "Determines whether to override the default Docker registry (quay.io) with an alternate container registry (e.g. docker.io). Defaults to false.",
             "fa_icon": "fas fa-question-circle",
@@ -578,7 +578,7 @@ params {
 
 2. Using an Optional Configuration File
 
-   - Alternatively, create an optional configuration file that includes the `override_default_container_registry` parameter with the desired default boolean value. Include this configuration file in the pipeline by using the `-c` option in commandline.
+   - Alternatively, create an optional configuration file that includes the `override_configured_docker_registry` parameter with the desired default boolean value. Include this configuration file in the pipeline by using the `-c` option in commandline.
 
 Example command:
 
@@ -586,7 +586,7 @@ Example command:
 nextflow run ... -c azure_configuration.config`
 ```
 
-This approach ensures that the `--override_default_container_registry` parameter is properly integrated and managed, allowing for flexible and dynamic container registry selection within your Nextflow pipeline.
+This approach ensures that the `--override_configured_docker_registry` parameter is properly integrated and managed, allowing for flexible and dynamic container registry selection within your Nextflow pipeline.
 
 <a name="resource-requirements"></a>
 

--- a/README.md
+++ b/README.md
@@ -525,7 +525,11 @@ When running on IRIDA Next, the Azure configuration file will automatically set 
 
 #### 5.2.2.1 Additional Configurations for Supporting the `--override_default_container_registry` Parameter
 
-To support the dynamic selection of container registries within IRIDA Next Nextflow pipeline modules when using the `--override_default_container_registry` parameter, the following additions need to be added to the `nextflow.config` and `nextflow_schema.json` files:
+To support the dynamic selection of container registries within IRIDA Next Nextflow pipeline modules when using the `--override_default_container_registry` parameter, additional Nextflow configuration files will either need to be updated, or implemented.
+
+1. Either update the nextflow.config file to inlcude the `override_deafult_container_registry`, or add an optional configuration file that is passed to the pipeline
+
+- e.g., `nextflow run ... -c azure_configuration.config`
 
 **nextflow.config**
 
@@ -535,7 +539,7 @@ Add the `override_default_container_registry` parameter to the `nextflow.config`
 params {
 
     // Override default container registry
-    override_default_container_registry = false
+    override_default_container_registry = true
 
 }
 ```
@@ -553,7 +557,8 @@ Add the new parameter to the definition input/output properties in the `nextflow
             "type": "boolean",
             "description": "Determines whether to override the default Docker registry (quay.io) with an alternate container registry (e.g. docker.io). Defaults to false.",
             "fa_icon": "fas fa-question-circle",
-            "default": false
+            "hidden": true,
+            "default": true
         }
       }
     }

--- a/README.md
+++ b/README.md
@@ -513,7 +513,7 @@ For more information, see the [Nextflow containers][] documentation and the [nf-
 
 ### 5.2.2 Configuring Module Software with Private or Alternate Container Registries
 
-To configure a private or alternate container registry, the standard practice is to set the `.registry` option to point to the desired resistry in the `nextflow.config` file. For example:
+To configure a private or alternate container registry, the standard practice is to set the `.registry` option to point to the desired registry in the `nextflow.config` file. For example:
 
 ```
 docker.registry = 'container-registry.com'
@@ -521,7 +521,7 @@ docker.registry = 'container-registry.com'
 
 This setting automatically prefixes each container name with the specified registry URL. In the above example, `biocontainers/fastqc:0.11.9--0` is transformed into `container-registry.com/biocontainers/fastqc:0.11.9--0`, ensuring that the container is downloaded from `container-registry.com`.
 
-In IRIDA Next Nextflow pipelines, we have chosen to adhere to nf-core standards by designating `quay.io` as the default container registry. This etup ensures that containers, such as `biocontainers/fastqc:0.11.9--0`, are automatically referenced as `quay.io/biocontainers/fastqc:0.11.9--0`. While this configuration simplifies container management, it can be restrictive when the pipeline requires containers from multiple registries, such as both `quay.io` and `docker.io`, since only one default registry can be configured at a time. Introducing flexibility in sourcing containers from different registries becomes valuable in situations where specific containers are only available in certain registries, or where there are preferences or restrictions on registry use.
+In IRIDA Next Nextflow pipelines, we have chosen to adhere to nf-core standards by designating `quay.io` as the default container registry. This setup ensures that containers, such as `biocontainers/fastqc:0.11.9--0`, are automatically referenced as `quay.io/biocontainers/fastqc:0.11.9--0`. While this configuration simplifies container management, it can be restrictive when the pipeline requires containers from multiple registries, such as both `quay.io` and `docker.io`, since only one default registry can be configured at a time. Introducing flexibility in sourcing containers from different registries becomes valuable in situations where specific containers are only available in certain registries, or where there are preferences or restrictions on registry use.
 
 To address this, we use `process.ext.override_configured_container_registry` to manage the selection of container registries dynamically by adding the following line to the `nextflow.config` file:
 

--- a/README.md
+++ b/README.md
@@ -539,10 +539,14 @@ To specify an alternative registry for a process, include a conditional check wi
 ```
 container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
     'https://depot.galaxyproject.org/singularity/fastqc:0.11.9--0' :
-    (task.ext.override_configured_container_registry ? 'docker.io/biocontainers/fastqc:v0.11.9_cv8' : 'biocontainers/fastqc:0.11.9--0') }"
+    task.ext.override_configured_container_registry != false ?
+    'docker.io/biocontainers/fastqc:v0.11.9_cv8' :
+    'biocontainers/fastqc:0.11.9--0' }"
 ```
 
 In this example, setting the `task.ext.override_configured_container_registry` in the container directive ensures the default Docker registry (`quay.io`) is overridden, allowing the process to use the DockerHub container registry (`docker.io`) instead.
+
+By using `!= false` in the condition, we ensure that the process will follow the alternative registry path whenever `task.ext.override_configured_container_registry` is set to any value other than `false` (including `true` or `null`). This approach provides flexibility by allowing different registry configurations to be applied without needing explicit overrides for every scenario.
 
 #### 5.2.2.1 Managing `process.ext.override_configured_container_registry` with Optional Configurations
 
@@ -556,7 +560,7 @@ For example, you can create a configuration file named `azure_configuration.conf
 // Azure-specific private registry to pull containers from
 docker.registry = "private-registry.com"
 
-// Azure-specific configuration for overriding the default Docker registry
+// Azure-specific configuration for overriding the default container registry
 process.ext.override_configured_container_registry = false
 ```
 


### PR DESCRIPTION
This PR updates the `README.md` to provide detailed instructions on configuring module software requirements to pull from multiple container registries. It introduces the use of a custom process extension, `process.ext.override_configured_container_registry`, in the `nextflow.config` file, and explains how to implement conditional checks as nested ternary operators within the `container` directive of relevant modules.