### PR TITLE
Update IRIDA Next install instructions to setup opensearch

### DIFF
--- a/docs/IRIDANext_LocalGuide.md
+++ b/docs/IRIDANext_LocalGuide.md
@@ -225,11 +225,29 @@ createuser -s test -P -U postgres
 # When prompted for a password for the `test` role above, set the password as `test`. These are the credentials used by the development and test databases.
 ```
 
-**8. Generate and configure the environment credentials**
+**8. Install Opensearch**
+
+[OpenSearch](https://opensearch.org/) is used by IRIDA Next for indexing and searching through metadata. In order to install opensearch please run the following:
+
+```bash
+sudo apt update
+
+sudo mkdir /var/run/opensearch
+# Change password here to your own custom password
+sudo OPENSEARCH_INITIAL_ADMIN_PASSWORD="password" apt install opensearch
+```
+
+Note, the passwords will need to be "strong". That is:
+
+> a minimum 8 character password and must contain at least one uppercase letter, one lowercase letter, one digit, and one special character that is strong.
+
+Note, if installation fails, you can check the log here `/var/log/opensearch/install_demo_configuration.log`. Failures may occur if the admin password isn't strong enough.
+
+**9. Generate and configure the environment credentials**
 
 Refer to [GA4GH WES Sapporo Setup](#ga4gh-wes-sapporo-setup-for-development) for how to setup and configure the IRIDA Next environment credentials for development purposes.
 
-**9. Initialize the databases**
+**10. Initialize the databases**
 
 _Run:_
 
@@ -238,11 +256,11 @@ cd /path/to/irida-next
 bin/rails db:create db:migrate db:seed
 ```
 
-**10. Register pipelines**
+**11. Register pipelines**
 
 Refer to [Registering pipelines in IRIDA Next](#registering-pipelines-in-irida-next) for how to register Nextflow pipelines.
 
-**11. Restarting**
+**12. Restarting**
 
 Rebuild and restart the sapporo docker container, restart postgres, and start Irida Next following the steps found here: [Running a local instance of IRIDA Next](#running-a-local-instance-of-irida-next).
 

--- a/docs/IRIDANext_LocalGuide.md
+++ b/docs/IRIDANext_LocalGuide.md
@@ -231,11 +231,9 @@ createuser -s test -P -U postgres
 
 ```bash
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+# Follow the brew instructions printed after installation to setup the environment
 
-# Setup brew environment
-echo >> /home/$HOME/.bashrc
-echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"' >> /home/$HOME/.bashrc
-eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+# Install some essential dependencies
 sudo apt-get install build-essential
 
 # Disable brew analytics

--- a/docs/IRIDANext_LocalGuide.md
+++ b/docs/IRIDANext_LocalGuide.md
@@ -227,21 +227,27 @@ createuser -s test -P -U postgres
 
 **8. Install Opensearch**
 
-[OpenSearch](https://opensearch.org/) is used by IRIDA Next for indexing and searching through metadata. In order to install opensearch please run the following:
+[OpenSearch](https://opensearch.org/) is used by IRIDA Next for indexing and searching through metadata. In order to install opensearch please first install [Homebrew](https://brew.sh/).
 
 ```bash
-sudo apt update
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
-sudo mkdir /var/run/opensearch
-# Change password here to your own custom password
-sudo OPENSEARCH_INITIAL_ADMIN_PASSWORD="password" apt install opensearch
+# Setup brew environment
+echo >> /home/$HOME/.bashrc
+echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"' >> /home/$HOME/.bashrc
+eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+sudo apt-get install build-essential
+
+# Disable brew analytics
+brew analytics off
 ```
 
-Note, the passwords will need to be "strong". That is:
+Next, you should be able to install and run opensearch with:
 
-> a minimum 8 character password and must contain at least one uppercase letter, one lowercase letter, one digit, and one special character that is strong.
-
-Note, if installation fails, you can check the log here `/var/log/opensearch/install_demo_configuration.log`. Failures may occur if the admin password isn't strong enough.
+```bash
+brew install opensearch
+brew services start opensearch
+```
 
 **9. Generate and configure the environment credentials**
 

--- a/docs/IRIDANext_LocalGuide.md
+++ b/docs/IRIDANext_LocalGuide.md
@@ -249,6 +249,12 @@ brew install opensearch
 brew services start opensearch
 ```
 
+Note, for **WSL/Ubuntu** the opensearch service won't start like this. Instead, you must run the `opensearch` binary yourself. As in:
+
+```bash
+opensearch
+```
+
 **9. Generate and configure the environment credentials**
 
 Refer to [GA4GH WES Sapporo Setup](#ga4gh-wes-sapporo-setup-for-development) for how to setup and configure the IRIDA Next environment credentials for development purposes.


### PR DESCRIPTION
IRIDA Next now requires [OpenSearch](https://opensearch.org/) to be setup and installed. This PR adds instructions for installing opensearch.